### PR TITLE
Improve stream playback error handling

### DIFF
--- a/SimpleAudioPlayer/AudioPlayer.cs
+++ b/SimpleAudioPlayer/AudioPlayer.cs
@@ -1,4 +1,4 @@
-﻿using SimpleAudioPlayer.Enums;
+using SimpleAudioPlayer.Enums;
 using SimpleAudioPlayer.Handles;
 using SimpleAudioPlayer.Native;
 
@@ -10,10 +10,15 @@ public class AudioPlayer: IDisposable
     private DeviceCallbacks _deviceCallbacks;
     private readonly AudioContextHandle _ctx;
     private bool _disposed;
+    private PlaybackState _playbackState = PlaybackState.Stopped;
 
     public Action<MaDeviceNotificationType>? DeviceNotificationChanged;
     public Action? PlayCompleted { get; set; }
-    
+    public Action<PlaybackState>? PlaybackStateChanged { get; set; }
+    public Action<PlaybackFailedEventArgs>? PlaybackFailed { get; set; }
+
+    public PlaybackState PlaybackState => _playbackState;
+
     public AudioPlayer(SampleFormat sampleFormat = SampleFormat.F32, uint channels = 2, uint sampleRate = 44100)
     {
         _ctx = NativeMethods.AudioContextCreate();
@@ -33,7 +38,7 @@ public class AudioPlayer: IDisposable
         }
 
         _deviceCallbacks.DeviceStateChanged = type => DeviceNotificationChanged?.Invoke(type);
-        _deviceCallbacks.PlayCompleted = () => PlayCompleted?.Invoke();
+        _deviceCallbacks.PlaybackStopped = OnNativePlaybackStopped;
     }
 
     public float Volume {
@@ -44,15 +49,15 @@ public class AudioPlayer: IDisposable
             {
                 var result = NativeMethods.SetVolume(_ctx, value);
             }
-        } 
+        }
     }
-    
+
     public double Time
     {
         get => GetTime();
         set => Seek(value);
     }
-    
+
     public double Duration => GetDuration();
 
     public void Load(IAudioCallbackHandler handler)
@@ -67,6 +72,8 @@ public class AudioPlayer: IDisposable
             callbacks.ReadProxy,
             callbacks.SeekProxy,
             callbacks.TellProxy,
+            callbacks.LengthProxy,
+            handler.CanSeek ? 1u : 0u,
             IntPtr.Zero);
 
         var oldCallbacks = _callbacks;
@@ -75,29 +82,76 @@ public class AudioPlayer: IDisposable
             _callbacks = null;
             callbacks.Dispose();
             oldCallbacks?.Dispose();
+            NotifyPlaybackFailed(result, null);
             throw new InvalidOperationException($"Failed to initialize audio decoder: {result}");
         }
 
         _callbacks = callbacks;
         oldCallbacks?.Dispose();
+        SetPlaybackState(PlaybackState.Stopped);
 
     }
 
     public bool Play()
     {
-        return _callbacks?.Handler != null && _callbacks.Handler.Play(_ctx);
+        if (_callbacks?.Handler == null)
+        {
+            return false;
+        }
+
+        var success = _callbacks.Handler.Play(_ctx);
+        if (success)
+        {
+            SetPlaybackState(PlaybackState.Playing);
+        }
+        else
+        {
+            NotifyPlaybackFailed(GetHandlerResult(), GetHandlerError());
+        }
+
+        return success;
     }
 
     public bool Pause()
     {
-        return _callbacks?.Handler != null && _callbacks.Handler.Pause(_ctx);
+        if (_callbacks?.Handler == null)
+        {
+            return false;
+        }
+
+        var success = _callbacks.Handler.Pause(_ctx);
+        if (success)
+        {
+            SetPlaybackState(PlaybackState.Paused);
+        }
+        else
+        {
+            NotifyPlaybackFailed(GetHandlerResult(), GetHandlerError());
+        }
+
+        return success;
     }
 
     public bool Stop()
     {
-        return _callbacks?.Handler != null && _callbacks.Handler.Stop(_ctx);
+        if (_callbacks?.Handler == null)
+        {
+            return false;
+        }
+
+        var success = _callbacks.Handler.Stop(_ctx);
+        if (success)
+        {
+            SetPlaybackState(PlaybackState.Stopped);
+        }
+        else
+        {
+            NotifyPlaybackFailed(GetHandlerResult(), GetHandlerError());
+        }
+
+        return success;
     }
-    
+
     public double GetDuration()
     {
         if (_callbacks?.Handler == null)
@@ -107,7 +161,7 @@ public class AudioPlayer: IDisposable
 
         return _callbacks.Handler.GetDuration(_ctx);
     }
-    
+
     public double GetTime()
     {
         if (_callbacks?.Handler == null)
@@ -120,14 +174,25 @@ public class AudioPlayer: IDisposable
 
     public bool Seek(double time)
     {
-        return _callbacks?.Handler != null && _callbacks.Handler.Seek(_ctx, time);
+        if (_callbacks?.Handler == null)
+        {
+            return false;
+        }
+
+        var success = _callbacks.Handler.Seek(_ctx, time);
+        if (!success)
+        {
+            NotifyPlaybackFailed(GetHandlerResult(), GetHandlerError());
+        }
+
+        return success;
     }
-    
+
     public PlayState GetPlayState()
     {
         return NativeMethods.GetPlayState(_ctx);
     }
-    
+
     public void Dispose()
     {
         if (_disposed)
@@ -141,5 +206,61 @@ public class AudioPlayer: IDisposable
         _callbacks?.Dispose();
         _deviceCallbacks.Dispose();
         GC.SuppressFinalize(this);
+    }
+
+    private void OnNativePlaybackStopped(MaResult result)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        var handlerResult = GetHandlerResult();
+        var handlerError = GetHandlerError();
+        if (IsFailure(result) || handlerError != null && IsFailure(handlerResult))
+        {
+            var failureResult = handlerError != null && IsFailure(handlerResult)
+                ? handlerResult
+                : result;
+            NotifyPlaybackFailed(failureResult, handlerError);
+            return;
+        }
+
+        SetPlaybackState(PlaybackState.Completed);
+        PlayCompleted?.Invoke();
+    }
+
+    private void SetPlaybackState(PlaybackState state)
+    {
+        if (_playbackState == state)
+        {
+            return;
+        }
+
+        _playbackState = state;
+        PlaybackStateChanged?.Invoke(state);
+    }
+
+    private void NotifyPlaybackFailed(MaResult result, Exception? exception)
+    {
+        SetPlaybackState(PlaybackState.Error);
+        PlaybackFailed?.Invoke(new PlaybackFailedEventArgs(result, exception));
+    }
+
+    private MaResult GetHandlerResult()
+    {
+        return _callbacks?.Handler is AudioCallbackHandlerBase handler
+            ? handler.LastResult
+            : MaResult.MaError;
+    }
+
+    private Exception? GetHandlerError()
+    {
+        return (_callbacks?.Handler as AudioCallbackHandlerBase)?.LastError;
+    }
+
+    private static bool IsFailure(MaResult result)
+    {
+        return result != MaResult.MaSuccess && result != MaResult.MaAtEnd;
     }
 }

--- a/SimpleAudioPlayer/Enums/ProgressiveDownloadState.cs
+++ b/SimpleAudioPlayer/Enums/ProgressiveDownloadState.cs
@@ -1,0 +1,10 @@
+namespace SimpleAudioPlayer.Enums;
+
+public enum ProgressiveDownloadState
+{
+    Downloading,
+    Completed,
+    Incomplete,
+    Failed,
+    Cancelled
+}

--- a/SimpleAudioPlayer/Handles/AudioCallbackHandlerBase.cs
+++ b/SimpleAudioPlayer/Handles/AudioCallbackHandlerBase.cs
@@ -1,38 +1,73 @@
-﻿using SimpleAudioPlayer.Enums;
+using SimpleAudioPlayer.Enums;
 using SimpleAudioPlayer.Native;
 
 namespace SimpleAudioPlayer.Handles;
 
 public abstract class AudioCallbackHandlerBase: IAudioCallbackHandler
 {
+    public MaResult LastResult { get; private set; } = MaResult.MaSuccess;
+    public Exception? LastError { get; private set; }
+    public virtual bool CanSeek => true;
+
     public abstract void Dispose();
     public abstract MaResult OnRead(IntPtr pDecoder, IntPtr pBuffer, nuint bytesToRead, out nuint bytesRead);
     public abstract MaResult OnSeek(IntPtr pDecoder, long offset, SeekOrigin origin);
     public abstract MaResult OnTell(IntPtr pDecoder, out long pCursor);
 
+    public virtual MaResult OnGetLength(out long length)
+    {
+        length = 0;
+        return MaResult.MaNotImplemented;
+    }
+
+    internal void SetLastError(MaResult result, Exception? error)
+    {
+        LastResult = result;
+        LastError = error;
+    }
+
+    protected void ClearLastError()
+    {
+        LastResult = MaResult.MaSuccess;
+        LastError = null;
+    }
+
+    protected MaResult Fail(MaResult result, Exception? error)
+    {
+        SetLastError(result, error);
+        return result;
+    }
+
+    private bool RecordNativeResult(MaResult result)
+    {
+        LastResult = result;
+        LastError = null;
+        return result == MaResult.MaSuccess;
+    }
+
     public virtual bool Play(AudioContextHandle ctx)
     {
-        return NativeMethods.AudioPlay(ctx) == MaResult.MaSuccess;
+        return RecordNativeResult(NativeMethods.AudioPlay(ctx));
     }
 
     public virtual bool Pause(AudioContextHandle ctx)
     {
-        return NativeMethods.AudioStop(ctx) == MaResult.MaSuccess;
+        return RecordNativeResult(NativeMethods.AudioStop(ctx));
     }
 
     public virtual bool Stop(AudioContextHandle ctx)
     {
-        if (NativeMethods.AudioStop(ctx) != MaResult.MaSuccess)
+        if (!RecordNativeResult(NativeMethods.AudioStop(ctx)))
         {
             return false;
         }
 
-        return NativeMethods.SeekToTime(ctx, 0) == MaResult.MaSuccess;
+        return RecordNativeResult(NativeMethods.SeekToTime(ctx, 0));
     }
 
     public virtual bool Seek(AudioContextHandle ctx, double time)
     {
-        return NativeMethods.SeekToTime(ctx, time) == MaResult.MaSuccess;
+        return RecordNativeResult(NativeMethods.SeekToTime(ctx, time));
     }
 
     public virtual double GetTime(AudioContextHandle ctx)

--- a/SimpleAudioPlayer/Handles/CachedStreamHandle.cs
+++ b/SimpleAudioPlayer/Handles/CachedStreamHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using SimpleAudioPlayer.Enums;
 
 namespace SimpleAudioPlayer.Handles
@@ -126,6 +126,7 @@ namespace SimpleAudioPlayer.Handles
         }
 
         public void Cancel() => _cts.Cancel();
+        public override bool CanSeek => _totalSize.HasValue || _isCompleted;
         #endregion
 
         #region 音频回调实现
@@ -133,57 +134,90 @@ namespace SimpleAudioPlayer.Handles
         {
             bytesRead = UIntPtr.Zero;
             if (_isDisposed) return MaResult.MaError;
+            if (bytesToRead > int.MaxValue) return MaResult.MaInvalidArgs;
 
-            // 等待数据可用或下载完成
-            while (!_isCompleted && _currentPosition >= _totalDownloaded)
+            while (true)
             {
-                if (!_dataAvailable.Wait(50, _cts.Token))
+                lock (_bufferLock)
                 {
-                    return _cts.IsCancellationRequested ? MaResult.MaError : MaResult.MaBusy;
-                }
-            }
+                    long available = _totalDownloaded - _currentPosition;
+                    if (available > 0)
+                    {
+                        int bytesToCopy = (int)Math.Min((long)bytesToRead, available);
+                        Marshal.Copy(_completeBuffer!, (int)_currentPosition, pBuffer, bytesToCopy);
 
-            lock (_bufferLock)
-            {
-                long available = _totalDownloaded - _currentPosition;
-                if (available <= 0)
+                        _currentPosition += bytesToCopy;
+                        bytesRead = (nuint)bytesToCopy;
+
+                        return MaResult.MaSuccess;
+                    }
+
+                    if (_error != null)
+                    {
+                        return Fail(MaResult.MaIoError, _error);
+                    }
+
+                    if (_isCompleted)
+                    {
+                        return MaResult.MaAtEnd;
+                    }
+                }
+
+                try
                 {
-                    return _isCompleted ? MaResult.MaAtEnd : MaResult.MaBusy;
+                    _dataAvailable.Wait(_cts.Token);
                 }
-
-                int bytesToCopy = (int)Math.Min((long)bytesToRead, available);
-                Marshal.Copy(_completeBuffer!, (int)_currentPosition, pBuffer, bytesToCopy);
-                
-                _currentPosition += bytesToCopy;
-                bytesRead = (nuint)bytesToCopy;
-                
-                return MaResult.MaSuccess;
+                catch (OperationCanceledException ex)
+                {
+                    return Fail(MaResult.MaCancelled, ex);
+                }
             }
         }
 
         public override MaResult OnSeek(IntPtr pDecoder, long offset, SeekOrigin origin)
         {
+            var knownLength = _totalSize ?? (_isCompleted ? _totalDownloaded : (long?)null);
+            if (origin == SeekOrigin.End && !knownLength.HasValue)
+            {
+                return MaResult.MaNotImplemented;
+            }
+
             long target = origin switch
             {
                 SeekOrigin.Begin => offset,
                 SeekOrigin.Current => Interlocked.Read(ref _currentPosition) + offset,
-                SeekOrigin.End => (_totalSize ?? _totalDownloaded) + offset,
+                SeekOrigin.End => knownLength!.Value + offset,
                 _ => throw new ArgumentOutOfRangeException(nameof(origin))
             };
+
+            if (target < 0)
+            {
+                return MaResult.MaInvalidArgs;
+            }
 
             // 等待数据下载到目标位置（如果必要）
             if (target > _totalDownloaded)
             {
                 if (_isCompleted) return MaResult.MaInvalidArgs;
-                
+
                 const int timeoutMs = 10000;
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                
+
                 while (target > _totalDownloaded)
                 {
+                    if (_error != null)
+                    {
+                        return Fail(MaResult.MaIoError, _error);
+                    }
+
+                    if (_cts.IsCancellationRequested)
+                    {
+                        return MaResult.MaCancelled;
+                    }
+
                     if (_isCompleted || sw.ElapsedMilliseconds > timeoutMs)
                         return MaResult.MaInvalidArgs;
-                    
+
                     Thread.Sleep(50);
                 }
             }
@@ -197,17 +231,42 @@ namespace SimpleAudioPlayer.Handles
             pCursor = Interlocked.Read(ref _currentPosition);
             return MaResult.MaSuccess;
         }
+
+        public override MaResult OnGetLength(out long length)
+        {
+            var knownLength = _totalSize ?? (_isCompleted ? _totalDownloaded : (long?)null);
+            if (!knownLength.HasValue)
+            {
+                length = 0;
+                return MaResult.MaNotImplemented;
+            }
+
+            length = knownLength.Value;
+            return MaResult.MaSuccess;
+        }
         #endregion
 
         #region 私有方法
         private void CompleteDownload(bool success, Exception? error)
         {
+            Action<bool, Exception?>? completed;
             lock (_bufferLock)
             {
                 _isCompleted = true;
                 _error = error;
-                DownloadCompleted?.Invoke(success, error);
+                if (success)
+                {
+                    ClearLastError();
+                }
+                else
+                {
+                    SetLastError(MaResult.MaIoError, error);
+                }
+
+                completed = DownloadCompleted;
             }
+
+            completed?.Invoke(success, error);
         }
         #endregion
 
@@ -218,12 +277,12 @@ namespace SimpleAudioPlayer.Handles
             _isDisposed = true;
 
             _cts.Cancel();
-            
+
             _downloadTask.ContinueWith(_ =>
             {
                 _dataAvailable.Dispose();
                 _cts.Dispose();
-                
+
                 lock (_bufferLock)
                 {
                     _completeBuffer = null; // 释放大内存块

--- a/SimpleAudioPlayer/Handles/CustomHandle.cs
+++ b/SimpleAudioPlayer/Handles/CustomHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using SimpleAudioPlayer.Enums;
 
 namespace SimpleAudioPlayer.Handles;
@@ -6,8 +6,12 @@ namespace SimpleAudioPlayer.Handles;
 public class CustomHandle(
     Func<byte[], int, int, int> onRead,
     Func<long, SeekOrigin, bool> onSeek,
-    Func<long> onTell): AudioCallbackHandlerBase
+    Func<long> onTell,
+    Func<long>? onGetLength = null,
+    bool canSeek = true): AudioCallbackHandlerBase
 {
+    public override bool CanSeek => canSeek;
+
     public override void Dispose()
     {
     }
@@ -18,7 +22,7 @@ public class CustomHandle(
         var read = onRead(buffer, 0, (int)bytesToRead);
         Marshal.Copy(buffer, 0, pBuffer, read);
         bytesRead = (UIntPtr)read;
-        
+
         return read > 0 ? MaResult.MaSuccess : MaResult.MaAtEnd;
     }
 
@@ -31,6 +35,18 @@ public class CustomHandle(
     {
         var cursor = onTell();
         pCursor = cursor;
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnGetLength(out long length)
+    {
+        if (onGetLength == null)
+        {
+            length = 0;
+            return MaResult.MaNotImplemented;
+        }
+
+        length = onGetLength();
         return MaResult.MaSuccess;
     }
 }

--- a/SimpleAudioPlayer/Handles/DiskCachedStreamHandle.cs
+++ b/SimpleAudioPlayer/Handles/DiskCachedStreamHandle.cs
@@ -1,0 +1,341 @@
+using System.Buffers;
+using System.Runtime.InteropServices;
+using SimpleAudioPlayer.Enums;
+
+namespace SimpleAudioPlayer.Handles;
+
+public sealed class DiskCachedStreamHandle : AudioCallbackHandlerBase
+{
+    private const int DefaultBufferSize = 81920;
+    private const int WaitTimeoutMs = 1000;
+    private const int SeekTimeoutMs = 10000;
+
+    private readonly Stream _sourceStream;
+    private readonly bool _leaveOpen;
+    private readonly bool _deleteCacheOnDispose;
+    private readonly bool _enableSeek;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly object _syncLock = new();
+    private readonly Task _downloadTask;
+    private readonly FileStream _cacheStream;
+
+    private long _totalDownloaded;
+    private long _currentPosition;
+    private long? _totalSize;
+    private bool _isCompleted;
+    private bool _isDisposed;
+    private bool _cacheCleaned;
+    private Exception? _error;
+
+    public DiskCachedStreamHandle(
+        Stream stream,
+        int bufferSize = DefaultBufferSize,
+        long totalSize = -1,
+        string? cacheFilePath = null,
+        bool? deleteCacheOnDispose = null,
+        bool enableSeek = false,
+        bool leaveOpen = false)
+    {
+        if (bufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bufferSize));
+        }
+
+        _sourceStream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _leaveOpen = leaveOpen;
+        _enableSeek = enableSeek;
+        _totalSize = totalSize > 0 ? totalSize : stream.CanSeek ? stream.Length : null;
+        CacheFilePath = cacheFilePath ?? Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.sapcache");
+        _deleteCacheOnDispose = deleteCacheOnDispose ?? cacheFilePath == null;
+
+        var directory = Path.GetDirectoryName(CacheFilePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        _cacheStream = new FileStream(
+            CacheFilePath,
+            FileMode.Create,
+            FileAccess.ReadWrite,
+            FileShare.Read,
+            bufferSize,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        _downloadTask = Task.Run(() => RunDownloadTask(bufferSize));
+    }
+
+    public event Action<long, long?>? ProgressChanged;
+    public event Action<bool, Exception?>? DownloadCompleted;
+
+    public string CacheFilePath { get; }
+    public long CachedBytes => Interlocked.Read(ref _totalDownloaded);
+    public long? TotalSize => _totalSize;
+    public bool IsCompleted => _isCompleted;
+    public override bool CanSeek => _enableSeek && _totalSize.HasValue;
+
+    public override MaResult OnRead(IntPtr pDecoder, IntPtr pBuffer, nuint bytesToRead, out nuint bytesRead)
+    {
+        bytesRead = 0;
+        if (_isDisposed) return MaResult.MaError;
+        if (bytesToRead > int.MaxValue) return MaResult.MaInvalidArgs;
+
+        var requested = (int)bytesToRead;
+        if (requested == 0)
+        {
+            return MaResult.MaSuccess;
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(requested);
+        try
+        {
+            while (true)
+            {
+                int read;
+                lock (_syncLock)
+                {
+                    if (_isDisposed) return MaResult.MaError;
+
+                    var available = _totalDownloaded - _currentPosition;
+                    if (available > 0)
+                    {
+                        var bytesToCopy = (int)Math.Min(requested, available);
+                        _cacheStream.Position = _currentPosition;
+                        read = _cacheStream.Read(rented, 0, bytesToCopy);
+                        if (read > 0)
+                        {
+                            _currentPosition += read;
+                            Marshal.Copy(rented, 0, pBuffer, read);
+                            bytesRead = (nuint)read;
+                            return MaResult.MaSuccess;
+                        }
+                    }
+
+                    if (_error != null)
+                    {
+                        return Fail(MaResult.MaIoError, _error);
+                    }
+
+                    if (_cts.IsCancellationRequested)
+                    {
+                        return MaResult.MaCancelled;
+                    }
+
+                    if (_isCompleted)
+                    {
+                        return MaResult.MaAtEnd;
+                    }
+
+                    Monitor.Wait(_syncLock, WaitTimeoutMs);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    public override MaResult OnSeek(IntPtr pDecoder, long offset, SeekOrigin origin)
+    {
+        if (!CanSeek)
+        {
+            return MaResult.MaNotImplemented;
+        }
+
+        var target = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => Interlocked.Read(ref _currentPosition) + offset,
+            SeekOrigin.End => _totalSize!.Value + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        if (target < 0 || target > _totalSize!.Value)
+        {
+            return MaResult.MaInvalidArgs;
+        }
+
+        var deadline = DateTime.UtcNow.AddMilliseconds(SeekTimeoutMs);
+        lock (_syncLock)
+        {
+            while (target > _totalDownloaded)
+            {
+                if (_error != null)
+                {
+                    return Fail(MaResult.MaIoError, _error);
+                }
+
+                if (_isCompleted || _cts.IsCancellationRequested)
+                {
+                    return MaResult.MaInvalidArgs;
+                }
+
+                var remaining = deadline - DateTime.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return MaResult.MaTimeout;
+                }
+
+                Monitor.Wait(_syncLock, Math.Min(WaitTimeoutMs, (int)remaining.TotalMilliseconds));
+            }
+
+            _currentPosition = target;
+            return MaResult.MaSuccess;
+        }
+    }
+
+    public override MaResult OnTell(IntPtr pDecoder, out long pCursor)
+    {
+        pCursor = Interlocked.Read(ref _currentPosition);
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnGetLength(out long length)
+    {
+        var knownLength = _totalSize ?? (_isCompleted ? _totalDownloaded : (long?)null);
+        if (!knownLength.HasValue)
+        {
+            length = 0;
+            return MaResult.MaNotImplemented;
+        }
+
+        length = knownLength.Value;
+        return MaResult.MaSuccess;
+    }
+
+    public void Cancel()
+    {
+        _cts.Cancel();
+        lock (_syncLock)
+        {
+            Monitor.PulseAll(_syncLock);
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _isDisposed = true;
+        Cancel();
+        if (!_leaveOpen)
+        {
+            _sourceStream.Dispose();
+        }
+
+        if (_downloadTask.IsCompleted)
+        {
+            CleanupCache();
+        }
+        else
+        {
+            _downloadTask.ContinueWith(_ => CleanupCache(), TaskScheduler.Default);
+        }
+    }
+
+    private async Task RunDownloadTask(int readBufferSize)
+    {
+        var readBuffer = ArrayPool<byte>.Shared.Rent(readBufferSize);
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                var bytesRead = await _sourceStream.ReadAsync(readBuffer, 0, readBufferSize, _cts.Token);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                lock (_syncLock)
+                {
+                    _cacheStream.Position = _totalDownloaded;
+                    _cacheStream.Write(readBuffer, 0, bytesRead);
+                    _totalDownloaded += bytesRead;
+                    Monitor.PulseAll(_syncLock);
+                }
+
+                ProgressChanged?.Invoke(Interlocked.Read(ref _totalDownloaded), _totalSize);
+            }
+
+            lock (_syncLock)
+            {
+                if (!_totalSize.HasValue)
+                {
+                    _totalSize = _totalDownloaded;
+                }
+
+                _isCompleted = true;
+                ClearLastError();
+                Monitor.PulseAll(_syncLock);
+            }
+
+            DownloadCompleted?.Invoke(true, null);
+        }
+        catch (OperationCanceledException)
+        {
+            lock (_syncLock)
+            {
+                Monitor.PulseAll(_syncLock);
+            }
+        }
+        catch (ObjectDisposedException) when (_isDisposed)
+        {
+            lock (_syncLock)
+            {
+                Monitor.PulseAll(_syncLock);
+            }
+        }
+        catch (Exception ex)
+        {
+            CompleteWithError(ex);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(readBuffer);
+        }
+    }
+
+    private void CompleteWithError(Exception error)
+    {
+        lock (_syncLock)
+        {
+            _error = error;
+            _isCompleted = true;
+            SetLastError(MaResult.MaIoError, error);
+            Monitor.PulseAll(_syncLock);
+        }
+
+        DownloadCompleted?.Invoke(false, error);
+    }
+
+    private void CleanupCache()
+    {
+        lock (_syncLock)
+        {
+            if (_cacheCleaned)
+            {
+                return;
+            }
+
+            _cacheCleaned = true;
+            _cacheStream.Dispose();
+        }
+
+        _cts.Dispose();
+        if (_deleteCacheOnDispose)
+        {
+            try
+            {
+                File.Delete(CacheFilePath);
+            }
+            catch
+            {
+                // Best effort cleanup.
+            }
+        }
+    }
+}

--- a/SimpleAudioPlayer/Handles/FileStreamHandle.cs
+++ b/SimpleAudioPlayer/Handles/FileStreamHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Runtime.InteropServices;
 using SimpleAudioPlayer.Enums;
 using SimpleAudioPlayer.Native;
@@ -8,6 +8,7 @@ namespace SimpleAudioPlayer.Handles;
 public class FileStreamHandler(string filePath) : AudioCallbackHandlerBase
 {
     private readonly FileStream _stream = File.OpenRead(filePath);
+    public override bool CanSeek => true;
 
     public override MaResult OnRead(
         IntPtr pDecoder,
@@ -47,8 +48,14 @@ public class FileStreamHandler(string filePath) : AudioCallbackHandlerBase
 
     public override MaResult OnTell(IntPtr pDecoder, out long pCursor)
     {
-        
+
         pCursor = _stream.Position;
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnGetLength(out long length)
+    {
+        length = _stream.Length;
         return MaResult.MaSuccess;
     }
 
@@ -56,11 +63,11 @@ public class FileStreamHandler(string filePath) : AudioCallbackHandlerBase
     {
         return base.Stop(ctx);
     }
-    
+
 
     public override void Dispose()
     {
         _stream.Dispose();
     }
-    
+
 }

--- a/SimpleAudioPlayer/Handles/HttpStreamHandle.cs
+++ b/SimpleAudioPlayer/Handles/HttpStreamHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using SimpleAudioPlayer.Enums;
@@ -11,6 +11,8 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
 {
     private const int BufferSize = 1 * 1024 * 1024; // 1MB环形缓冲区
     private const int WaitTimeoutMs = 1000;
+    private const int MaxRetryCount = 3;
+    private const int RetryDelayMs = 500;
 
     private readonly string _url;
     private readonly HttpClient _httpClient;
@@ -19,15 +21,16 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
     private readonly long _fileSize;
     private readonly object _syncLock = new();
     private readonly byte[] _ringBuffer;
-    
+
     private int _readPos;
     private int _writePos;
     private int _bytesAvailable;
     private long _virtualPosition;
+    private long _downloadPosition;
     private bool _disposed;
     private bool _downloadCompleted;
-    private bool _getLength;
-    
+    private Exception? _downloadError;
+
     private Stream? _responseStream;
     private Task? _downloadTask;
     private CancellationTokenSource? _cts;
@@ -43,7 +46,9 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
 
         StartDownload(_virtualPosition);
     }
-    
+
+    public override bool CanSeek => _supportRange;
+
     public static async Task<HttpStreamHandle> CreateAsync(string url, HttpClient? client = null)
     {
         var httpClient = client ?? new HttpClient();
@@ -55,65 +60,39 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
     {
         var cts = new CancellationTokenSource();
         _cts = cts;
+        lock (_syncLock)
+        {
+            _downloadCompleted = false;
+            _downloadError = null;
+            _downloadPosition = startPosition;
+        }
+        ClearLastError();
+
         _downloadTask = Task.Run(async () =>
         {
+            var nextPosition = startPosition;
+            var retryCount = 0;
+
             try
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, _url);
-                if (_supportRange)
-                    request.Headers.Range = new RangeHeaderValue(startPosition, null);
-
-                using var response = await _httpClient.SendAsync(
-                    request, 
-                    HttpCompletionOption.ResponseHeadersRead,
-                    cts.Token);
-
-                using var responseStream = await response.Content.ReadAsStreamAsync();
-                _responseStream = responseStream;
-
-                var buffer = ArrayPool<byte>.Shared.Rent(8192);
-                try
+                while (!cts.IsCancellationRequested)
                 {
-                    while (!cts.IsCancellationRequested)
+                    try
                     {
-                        // 等待缓冲区空间
-                        lock (_syncLock)
-                        {
-                            while (BufferSize - _bytesAvailable == 0 && !cts.IsCancellationRequested)
-                            {
-                                Monitor.Wait(_syncLock, WaitTimeoutMs);
-                            }
-                            
-                            if (cts.IsCancellationRequested)
-                            {
-                                break;
-                            }
-                        }
-
-                        var bytesRead = await responseStream.ReadAsync(
-                            buffer, 0, Math.Min(buffer.Length, BufferSize - _bytesAvailable), cts.Token);
-                        
-                        if (bytesRead == 0)
-                        {
-                            lock (_syncLock)
-                            {
-                                _downloadCompleted = true;
-                                Monitor.PulseAll(_syncLock);
-                            }
-                            break;
-                        }
-
-                        lock (_syncLock)
-                        {
-                            WriteToBuffer(buffer, 0, bytesRead);
-                            _bytesAvailable += bytesRead;
-                            Monitor.PulseAll(_syncLock);
-                        }
+                        nextPosition = await DownloadSegmentAsync(nextPosition, cts.Token);
+                        MarkDownloadCompleted();
+                        break;
                     }
-                }
-                finally
-                {
-                    ArrayPool<byte>.Shared.Return(buffer);
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (Exception) when (_supportRange && retryCount < MaxRetryCount)
+                    {
+                        retryCount++;
+                        nextPosition = GetDownloadPosition();
+                        await Task.Delay(RetryDelayMs, cts.Token);
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -122,23 +101,116 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Download error: {ex.Message}");
-                lock (_syncLock)
-                {
-                    _downloadCompleted = true;
-                    Monitor.PulseAll(_syncLock);
-                }
+                MarkDownloadFailed(ex);
             }
         }, cts.Token);
+    }
+
+    private async Task<long> DownloadSegmentAsync(long startPosition, CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, _url);
+        if (_supportRange)
+            request.Headers.Range = new RangeHeaderValue(startPosition, null);
+
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        using var responseStream = await response.Content.ReadAsStreamAsync();
+        _responseStream = responseStream;
+
+        var expectedEnd = response.Content.Headers.ContentLength.HasValue
+            ? startPosition + response.Content.Headers.ContentLength.Value
+            : _fileSize > 0 ? _fileSize : (long?)null;
+        var nextPosition = startPosition;
+        var buffer = ArrayPool<byte>.Shared.Rent(8192);
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                int bytesToRequest;
+                lock (_syncLock)
+                {
+                    while (BufferSize - _bytesAvailable == 0 && !cancellationToken.IsCancellationRequested)
+                    {
+                        Monitor.Wait(_syncLock, WaitTimeoutMs);
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    bytesToRequest = Math.Min(buffer.Length, BufferSize - _bytesAvailable);
+                }
+
+                var bytesRead = await responseStream.ReadAsync(
+                    buffer, 0, bytesToRequest, cancellationToken);
+
+                if (bytesRead == 0)
+                {
+                    if (expectedEnd.HasValue && nextPosition < expectedEnd.Value)
+                    {
+                        throw new EndOfStreamException("HTTP stream ended before the expected content length.");
+                    }
+
+                    return nextPosition;
+                }
+
+                lock (_syncLock)
+                {
+                    WriteToBuffer(buffer, 0, bytesRead);
+                    _bytesAvailable += bytesRead;
+                    _downloadPosition = nextPosition + bytesRead;
+                    Monitor.PulseAll(_syncLock);
+                }
+
+                nextPosition += bytesRead;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return nextPosition;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private void MarkDownloadCompleted()
+    {
+        lock (_syncLock)
+        {
+            _downloadCompleted = true;
+            Monitor.PulseAll(_syncLock);
+        }
+    }
+
+    private void MarkDownloadFailed(Exception error)
+    {
+        lock (_syncLock)
+        {
+            _downloadError = error;
+            _downloadCompleted = true;
+            SetLastError(MaResult.MaIoError, error);
+            Monitor.PulseAll(_syncLock);
+        }
+    }
+
+    private long GetDownloadPosition()
+    {
+        lock (_syncLock)
+        {
+            return _downloadPosition;
+        }
     }
 
     private void WriteToBuffer(byte[] data, int offset, int count)
     {
         var firstChunk = Math.Min(count, BufferSize - _writePos);
         Buffer.BlockCopy(data, offset, _ringBuffer, _writePos, firstChunk);
-        
+
         _writePos = (_writePos + firstChunk) % BufferSize;
-        
+
         var remaining = count - firstChunk;
         if (remaining > 0)
         {
@@ -151,7 +223,7 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
     {
         bytesRead = UIntPtr.Zero;
         var remaining = (int)bytesToRead;
-        
+
         try
         {
             while (remaining > 0 && _cts?.IsCancellationRequested != true)
@@ -160,12 +232,12 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
                 {
                     if (_bytesAvailable > 0)
                     {
-                        var read = ReadFromBuffer(pBuffer, (int)bytesToRead - remaining, 
+                        var read = ReadFromBuffer(pBuffer, (int)bytesToRead - remaining,
                             Math.Min(remaining, _bytesAvailable));
                         _virtualPosition += read;
                         bytesRead = (UIntPtr)((int)bytesRead + read);
                         remaining -= read;
-                        
+
                         // 如果释放了足够空间，通知下载线程
                         if (BufferSize - _bytesAvailable > BufferSize / 2)
                         {
@@ -173,24 +245,30 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
                         }
                         continue;
                     }
-                    
+
                     if (_downloadCompleted)
                     {
-                        return remaining == (int)bytesToRead ? 
-                            MaResult.MaAtEnd : 
+                        if (_downloadError != null)
+                        {
+                            return bytesRead == 0
+                                ? Fail(MaResult.MaIoError, _downloadError)
+                                : MaResult.MaSuccess;
+                        }
+
+                        return remaining == (int)bytesToRead ?
+                            MaResult.MaAtEnd :
                             MaResult.MaSuccess;
                     }
-                    
+
                     Monitor.Wait(_syncLock, WaitTimeoutMs);
                 }
             }
-            
+
             return MaResult.MaSuccess;
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Read error: {ex.Message}");
-            return MaResult.MaError;
+            return Fail(MaResult.MaError, ex);
         }
     }
 
@@ -201,9 +279,9 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
 
         while (count > 0 && _bytesAvailable > 0)
         {
-            var bytesToCopy = Math.Min(count, 
-                _readPos < _writePos ? 
-                    _writePos - _readPos : 
+            var bytesToCopy = Math.Min(count,
+                _readPos < _writePos ?
+                    _writePos - _readPos :
                     BufferSize - _readPos);
 
             fixed (byte* src = &_ringBuffer[_readPos])
@@ -217,7 +295,7 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
             count -= bytesToCopy;
             read += bytesToCopy;
         }
-        
+
         return read;
     }
 
@@ -226,10 +304,9 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
         if (!_supportRange)
             return MaResult.MaInvalidOperation;
 
-        if (origin == SeekOrigin.End && offset == 0)
+        if (origin == SeekOrigin.End && _fileSize <= 0)
         {
-            _getLength = true;
-            return MaResult.MaSuccess;
+            return MaResult.MaNotImplemented;
         }
 
         try
@@ -247,7 +324,7 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
         {
             // 忽略取消异常
         }
-        
+
         lock (_syncLock)
         {
             var newPosition = origin switch
@@ -258,34 +335,46 @@ public sealed class HttpStreamHandle : AudioCallbackHandlerBase
                 _ => throw new NotSupportedException()
             };
 
+            if (newPosition < 0)
+            {
+                return MaResult.MaInvalidArgs;
+            }
+
             // 重置缓冲区状态
             _readPos = 0;
             _writePos = 0;
             _bytesAvailable = 0;
             _virtualPosition = newPosition;
+            _downloadPosition = newPosition;
             _downloadCompleted = false;
+            _downloadError = null;
 
             // 重新启动下载任务
-            StartDownload(newPosition); 
+            StartDownload(newPosition);
         }
-        
+
         return MaResult.MaSuccess;
     }
 
     public override MaResult OnTell(IntPtr pDecoder, out long pCursor)
     {
-        if (_getLength)
-        {
-            pCursor = _fileSize;
-            _getLength = false;
-            return MaResult.MaSuccess;
-        }
-        
         lock (_syncLock)
         {
             pCursor = _virtualPosition;
         }
-        
+
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnGetLength(out long length)
+    {
+        if (_fileSize <= 0)
+        {
+            length = 0;
+            return MaResult.MaNotImplemented;
+        }
+
+        length = _fileSize;
         return MaResult.MaSuccess;
     }
 

--- a/SimpleAudioPlayer/Handles/IAudioCallbackHandler.cs
+++ b/SimpleAudioPlayer/Handles/IAudioCallbackHandler.cs
@@ -1,13 +1,16 @@
-﻿using SimpleAudioPlayer.Enums;
+using SimpleAudioPlayer.Enums;
 using SimpleAudioPlayer.Native;
 
 namespace SimpleAudioPlayer.Handles;
 
 public interface IAudioCallbackHandler: IDisposable
 {
+    bool CanSeek { get; }
+
     MaResult OnRead(IntPtr pDecoder, IntPtr pBuffer, nuint bytesToRead, out nuint bytesRead);
     MaResult OnSeek(IntPtr pDecoder, long offset, SeekOrigin origin);
     MaResult OnTell(IntPtr pDecoder, out long pCursor);
+    MaResult OnGetLength(out long length);
 
     bool Play(AudioContextHandle ctx);
     bool Pause(AudioContextHandle ctx);
@@ -16,5 +19,5 @@ public interface IAudioCallbackHandler: IDisposable
     bool Seek(AudioContextHandle ctx, double time);
     double GetTime(AudioContextHandle ctx);
     double GetDuration(AudioContextHandle ctx);
-    
+
 }

--- a/SimpleAudioPlayer/Handles/ProgressiveHttpStreamHandle.cs
+++ b/SimpleAudioPlayer/Handles/ProgressiveHttpStreamHandle.cs
@@ -1,0 +1,803 @@
+using System.Buffers;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using SimpleAudioPlayer.Enums;
+using SimpleAudioPlayer.Native;
+using SimpleAudioPlayer.Utils;
+
+namespace SimpleAudioPlayer.Handles;
+
+public sealed class ProgressiveHttpStreamHandle : AudioCallbackHandlerBase
+{
+    private const int DefaultReadBufferSize = 81920;
+    private const int PlaybackBufferSize = 1 * 1024 * 1024;
+    private const int WaitTimeoutMs = 1000;
+    private const int MaxRetryCount = 3;
+    private const int RetryDelayMs = 500;
+
+    private readonly string _url;
+    private readonly HttpClient _httpClient;
+    private readonly bool _disposeHttpClient;
+    private readonly bool _deletePartialOnDispose;
+    private readonly bool _supportsRange;
+    private readonly long _fileSize;
+    private readonly object _syncLock = new();
+    private readonly byte[] _playbackBuffer = new byte[PlaybackBufferSize];
+
+    private FileStream? _cacheStream;
+    private CancellationTokenSource? _downloadCts;
+    private CancellationTokenSource? _streamCts;
+    private Task? _downloadTask;
+    private Task? _streamTask;
+    private Exception? _downloadError;
+    private Exception? _streamError;
+    private ProgressiveDownloadState _downloadState = ProgressiveDownloadState.Downloading;
+
+    private long _prefixDownloaded;
+    private long _currentPosition;
+    private long _streamDownloadPosition;
+    private int _readPos;
+    private int _writePos;
+    private int _bytesAvailable;
+    private bool _streamCompleted;
+    private bool _useStreamingPlayback;
+    private bool _disposed;
+    private int _userSeekDepth;
+
+    private ProgressiveHttpStreamHandle(
+        string url,
+        HttpClient httpClient,
+        long fileSize,
+        bool supportsRange,
+        string finalFilePath,
+        bool overwrite,
+        bool deletePartialOnDispose,
+        bool disposeHttpClient,
+        int readBufferSize)
+    {
+        _url = url;
+        _httpClient = httpClient;
+        _fileSize = fileSize;
+        _supportsRange = supportsRange;
+        _disposeHttpClient = disposeHttpClient;
+        _deletePartialOnDispose = deletePartialOnDispose;
+        FinalFilePath = Path.GetFullPath(finalFilePath);
+        PartialFilePath = FinalFilePath + ".part";
+
+        PrepareOutputFiles(overwrite);
+        _cacheStream = new FileStream(
+            PartialFilePath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.Read,
+            readBufferSize,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        StartCompleteDownload(readBufferSize);
+    }
+
+    public event Action<long, long?>? ProgressChanged;
+    public event EventHandler<ProgressiveDownloadStateChangedEventArgs>? DownloadStateChanged;
+
+    public string PartialFilePath { get; }
+    public string FinalFilePath { get; }
+    public long DownloadedBytes => Interlocked.Read(ref _prefixDownloaded);
+    public long TotalBytes => _fileSize;
+    public ProgressiveDownloadState DownloadState => _downloadState;
+    public override bool CanSeek => _supportsRange;
+
+    public static async Task<ProgressiveHttpStreamHandle> CreateAsync(
+        string url,
+        string finalFilePath,
+        HttpClient? client = null,
+        int readBufferSize = DefaultReadBufferSize,
+        bool overwrite = false,
+        bool deletePartialOnDispose = false)
+    {
+        if (readBufferSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(readBufferSize));
+        }
+
+        var httpClient = client ?? new HttpClient();
+        var rangeInfo = await httpClient.CheckRangeSupportWithSizeAsync(url);
+
+        return new ProgressiveHttpStreamHandle(
+            url,
+            httpClient,
+            rangeInfo.FileSize ?? 0,
+            rangeInfo.SupportsRange,
+            finalFilePath,
+            overwrite,
+            deletePartialOnDispose,
+            client == null,
+            readBufferSize);
+    }
+
+    public override MaResult OnRead(IntPtr pDecoder, IntPtr pBuffer, nuint bytesToRead, out nuint bytesRead)
+    {
+        bytesRead = 0;
+        if (_disposed) return MaResult.MaError;
+        if (bytesToRead > int.MaxValue) return MaResult.MaInvalidArgs;
+
+        return _useStreamingPlayback
+            ? ReadFromStreamingBuffer(pBuffer, (int)bytesToRead, out bytesRead)
+            : ReadFromProgressiveFile(pBuffer, (int)bytesToRead, out bytesRead);
+    }
+
+    public override MaResult OnSeek(IntPtr pDecoder, long offset, SeekOrigin origin)
+    {
+        if (!_supportsRange)
+        {
+            return MaResult.MaNotImplemented;
+        }
+
+        if (origin == SeekOrigin.End && _fileSize <= 0)
+        {
+            return MaResult.MaNotImplemented;
+        }
+
+        var target = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => Interlocked.Read(ref _currentPosition) + offset,
+            SeekOrigin.End => _fileSize + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        if (target < 0 || _fileSize > 0 && target > _fileSize)
+        {
+            return MaResult.MaInvalidArgs;
+        }
+
+        var seekedToCache = false;
+        var shouldCancelRangeRead = false;
+        lock (_syncLock)
+        {
+            if (_downloadState != ProgressiveDownloadState.Incomplete && target <= _prefixDownloaded)
+            {
+                seekedToCache = true;
+                shouldCancelRangeRead = _useStreamingPlayback;
+                _useStreamingPlayback = false;
+                _currentPosition = target;
+                Monitor.PulseAll(_syncLock);
+            }
+        }
+
+        if (seekedToCache)
+        {
+            if (shouldCancelRangeRead)
+            {
+                CancelStreamingPlayback();
+            }
+
+            return MaResult.MaSuccess;
+        }
+
+        var isUserSeek = Interlocked.CompareExchange(ref _userSeekDepth, 0, 0) > 0;
+        if (isUserSeek)
+        {
+            MarkDownloadIncomplete();
+        }
+
+        StartStreamingPlayback(target);
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnTell(IntPtr pDecoder, out long pCursor)
+    {
+        pCursor = Interlocked.Read(ref _currentPosition);
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnGetLength(out long length)
+    {
+        if (_fileSize <= 0)
+        {
+            length = 0;
+            return MaResult.MaNotImplemented;
+        }
+
+        length = _fileSize;
+        return MaResult.MaSuccess;
+    }
+
+    public override bool Seek(AudioContextHandle ctx, double time)
+    {
+        Interlocked.Increment(ref _userSeekDepth);
+        try
+        {
+            return base.Seek(ctx, time);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _userSeekDepth);
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        CancelDownload(ProgressiveDownloadState.Cancelled);
+        CancelStreamingPlayback();
+
+        lock (_syncLock)
+        {
+            _cacheStream?.Dispose();
+            _cacheStream = null;
+            Monitor.PulseAll(_syncLock);
+        }
+
+        _downloadCts?.Dispose();
+        _streamCts?.Dispose();
+        if (_disposeHttpClient)
+        {
+            _httpClient.Dispose();
+        }
+
+        if (_deletePartialOnDispose && File.Exists(PartialFilePath))
+        {
+            TryDelete(PartialFilePath);
+        }
+    }
+
+    private MaResult ReadFromProgressiveFile(IntPtr pBuffer, int bytesToRead, out nuint bytesRead)
+    {
+        bytesRead = 0;
+        if (bytesToRead == 0)
+        {
+            return MaResult.MaSuccess;
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(bytesToRead);
+        try
+        {
+            while (true)
+            {
+                lock (_syncLock)
+                {
+                    if (_downloadError != null)
+                    {
+                        return Fail(MaResult.MaIoError, _downloadError);
+                    }
+
+                    var available = _prefixDownloaded - _currentPosition;
+                    if (available > 0 && _cacheStream != null)
+                    {
+                        var bytesToCopy = (int)Math.Min(bytesToRead, available);
+                        _cacheStream.Position = _currentPosition;
+                        var read = _cacheStream.Read(rented, 0, bytesToCopy);
+                        if (read > 0)
+                        {
+                            _currentPosition += read;
+                            Marshal.Copy(rented, 0, pBuffer, read);
+                            bytesRead = (nuint)read;
+                            return MaResult.MaSuccess;
+                        }
+                    }
+
+                    if (_downloadState == ProgressiveDownloadState.Completed &&
+                        (_fileSize <= 0 || _currentPosition >= _fileSize))
+                    {
+                        return MaResult.MaAtEnd;
+                    }
+
+                    if (_downloadState is ProgressiveDownloadState.Failed or ProgressiveDownloadState.Cancelled)
+                    {
+                        return Fail(MaResult.MaIoError, _downloadError);
+                    }
+
+                    Monitor.Wait(_syncLock, WaitTimeoutMs);
+                }
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private MaResult ReadFromStreamingBuffer(IntPtr pBuffer, int bytesToRead, out nuint bytesRead)
+    {
+        bytesRead = 0;
+        var remaining = bytesToRead;
+
+        try
+        {
+            while (remaining > 0)
+            {
+                lock (_syncLock)
+                {
+                    if (_bytesAvailable > 0)
+                    {
+                        var read = ReadFromRingBuffer(pBuffer, bytesToRead - remaining, Math.Min(remaining, _bytesAvailable));
+                        _currentPosition += read;
+                        bytesRead = (nuint)((int)bytesRead + read);
+                        remaining -= read;
+
+                        if (PlaybackBufferSize - _bytesAvailable > PlaybackBufferSize / 2)
+                        {
+                            Monitor.PulseAll(_syncLock);
+                        }
+
+                        continue;
+                    }
+
+                    if (_streamError != null)
+                    {
+                        return bytesRead == 0
+                            ? Fail(MaResult.MaIoError, _streamError)
+                            : MaResult.MaSuccess;
+                    }
+
+                    if (_streamCompleted)
+                    {
+                        return bytesRead == 0 ? MaResult.MaAtEnd : MaResult.MaSuccess;
+                    }
+
+                    Monitor.Wait(_syncLock, WaitTimeoutMs);
+                }
+            }
+
+            return MaResult.MaSuccess;
+        }
+        catch (Exception ex)
+        {
+            return Fail(MaResult.MaError, ex);
+        }
+    }
+
+    private void StartCompleteDownload(int readBufferSize)
+    {
+        var cts = new CancellationTokenSource();
+        _downloadCts = cts;
+        _downloadTask = Task.Run(() => RunCompleteDownloadAsync(readBufferSize, cts.Token), cts.Token);
+    }
+
+    private async Task RunCompleteDownloadAsync(int readBufferSize, CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(readBufferSize);
+        try
+        {
+            await using var responseStream = await OpenHttpStreamAsync(0, cancellationToken);
+            var nextPosition = 0L;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var read = await responseStream.ReadAsync(buffer, 0, readBufferSize, cancellationToken);
+                if (read == 0)
+                {
+                    break;
+                }
+
+                lock (_syncLock)
+                {
+                    if (_cacheStream == null)
+                    {
+                        return;
+                    }
+
+                    _cacheStream.Position = nextPosition;
+                    _cacheStream.Write(buffer, 0, read);
+                    nextPosition += read;
+                    _prefixDownloaded = nextPosition;
+                    Monitor.PulseAll(_syncLock);
+                }
+
+                ProgressChanged?.Invoke(
+                    Interlocked.Read(ref _prefixDownloaded),
+                    _fileSize > 0 ? _fileSize : null);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_fileSize > 0 && nextPosition < _fileSize)
+            {
+                throw new EndOfStreamException("HTTP stream ended before the expected content length.");
+            }
+
+            CompleteDownload();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException) when (_disposed)
+        {
+        }
+        catch (Exception ex)
+        {
+            FailDownload(ex);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private void StartStreamingPlayback(long startPosition)
+    {
+        if (!_supportsRange)
+        {
+            lock (_syncLock)
+            {
+                _streamError = new NotSupportedException("HTTP server does not support range requests.");
+                _streamCompleted = true;
+                Monitor.PulseAll(_syncLock);
+            }
+
+            return;
+        }
+
+        CancelStreamingPlayback();
+
+        lock (_syncLock)
+        {
+            _readPos = 0;
+            _writePos = 0;
+            _bytesAvailable = 0;
+            _currentPosition = startPosition;
+            _streamDownloadPosition = startPosition;
+            _streamCompleted = false;
+            _streamError = null;
+            _useStreamingPlayback = true;
+            Monitor.PulseAll(_syncLock);
+        }
+
+        if (_fileSize > 0 && startPosition >= _fileSize)
+        {
+            return;
+        }
+
+        var cts = new CancellationTokenSource();
+        _streamCts = cts;
+        _streamTask = Task.Run(() => RunStreamingPlaybackAsync(startPosition, cts.Token), cts.Token);
+    }
+
+    private async Task RunStreamingPlaybackAsync(long startPosition, CancellationToken cancellationToken)
+    {
+        var nextPosition = startPosition;
+        var retryCount = 0;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    nextPosition = await DownloadPlaybackSegmentAsync(nextPosition, cancellationToken);
+                    lock (_syncLock)
+                    {
+                        _streamCompleted = true;
+                        Monitor.PulseAll(_syncLock);
+                    }
+
+                    break;
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception) when (retryCount < MaxRetryCount)
+                {
+                    retryCount++;
+                    lock (_syncLock)
+                    {
+                        nextPosition = _streamDownloadPosition;
+                    }
+
+                    await Task.Delay(RetryDelayMs, cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            lock (_syncLock)
+            {
+                _streamError = ex;
+                _streamCompleted = true;
+                Monitor.PulseAll(_syncLock);
+            }
+        }
+    }
+
+    private async Task<long> DownloadPlaybackSegmentAsync(long startPosition, CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(DefaultReadBufferSize);
+        try
+        {
+            await using var responseStream = await OpenHttpStreamAsync(startPosition, cancellationToken);
+            var nextPosition = startPosition;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                int bytesToRequest;
+                lock (_syncLock)
+                {
+                    while (PlaybackBufferSize - _bytesAvailable == 0 && !cancellationToken.IsCancellationRequested)
+                    {
+                        Monitor.Wait(_syncLock, WaitTimeoutMs);
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    bytesToRequest = Math.Min(buffer.Length, PlaybackBufferSize - _bytesAvailable);
+                }
+
+                var read = await responseStream.ReadAsync(buffer, 0, bytesToRequest, cancellationToken);
+                if (read == 0)
+                {
+                    if (_fileSize > 0 && nextPosition < _fileSize)
+                    {
+                        throw new EndOfStreamException("HTTP stream ended before the expected content length.");
+                    }
+
+                    return nextPosition;
+                }
+
+                lock (_syncLock)
+                {
+                    WriteToRingBuffer(buffer, 0, read);
+                    _bytesAvailable += read;
+                    nextPosition += read;
+                    _streamDownloadPosition = nextPosition;
+                    Monitor.PulseAll(_syncLock);
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return nextPosition;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async Task<Stream> OpenHttpStreamAsync(long startPosition, CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, _url);
+        if (_supportsRange)
+        {
+            request.Headers.Range = new RangeHeaderValue(startPosition, null);
+        }
+        else if (startPosition > 0)
+        {
+            throw new NotSupportedException("HTTP server does not support range requests.");
+        }
+
+        var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        if (_supportsRange && startPosition > 0 && response.StatusCode != HttpStatusCode.PartialContent)
+        {
+            response.Dispose();
+            throw new InvalidDataException("HTTP server did not return a partial response for the requested range.");
+        }
+
+        var expectedLength = response.Content.Headers.ContentLength;
+        if (_fileSize > 0 && expectedLength.HasValue && startPosition + expectedLength.Value > _fileSize)
+        {
+            response.Dispose();
+            throw new InvalidDataException("HTTP response length exceeds the declared file size.");
+        }
+
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return new ResponseStream(response, stream);
+    }
+
+    private unsafe int ReadFromRingBuffer(IntPtr dest, int offset, int count)
+    {
+        var read = 0;
+        var destPtr = (byte*)dest.ToPointer() + offset;
+
+        while (count > 0 && _bytesAvailable > 0)
+        {
+            var bytesToCopy = Math.Min(count,
+                _readPos < _writePos
+                    ? _writePos - _readPos
+                    : PlaybackBufferSize - _readPos);
+
+            fixed (byte* src = &_playbackBuffer[_readPos])
+            {
+                Buffer.MemoryCopy(src, destPtr, bytesToCopy, bytesToCopy);
+            }
+
+            _readPos = (_readPos + bytesToCopy) % PlaybackBufferSize;
+            _bytesAvailable -= bytesToCopy;
+            destPtr += bytesToCopy;
+            count -= bytesToCopy;
+            read += bytesToCopy;
+        }
+
+        return read;
+    }
+
+    private void WriteToRingBuffer(byte[] data, int offset, int count)
+    {
+        var firstChunk = Math.Min(count, PlaybackBufferSize - _writePos);
+        Buffer.BlockCopy(data, offset, _playbackBuffer, _writePos, firstChunk);
+        _writePos = (_writePos + firstChunk) % PlaybackBufferSize;
+
+        var remaining = count - firstChunk;
+        if (remaining > 0)
+        {
+            Buffer.BlockCopy(data, offset + firstChunk, _playbackBuffer, _writePos, remaining);
+            _writePos = (_writePos + remaining) % PlaybackBufferSize;
+        }
+    }
+
+    private void CompleteDownload()
+    {
+        lock (_syncLock)
+        {
+            if (_downloadState == ProgressiveDownloadState.Incomplete || _cacheStream == null)
+            {
+                return;
+            }
+
+            _cacheStream.Flush(true);
+            _cacheStream.Dispose();
+            _cacheStream = null;
+            if (File.Exists(FinalFilePath))
+            {
+                File.Delete(FinalFilePath);
+            }
+
+            File.Move(PartialFilePath, FinalFilePath);
+            _cacheStream = new FileStream(FinalFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            SetDownloadState(ProgressiveDownloadState.Completed, null);
+            ClearLastError();
+            Monitor.PulseAll(_syncLock);
+        }
+    }
+
+    private void MarkDownloadIncomplete()
+    {
+        var oldCts = _downloadCts;
+        if (_downloadState == ProgressiveDownloadState.Downloading)
+        {
+            oldCts?.Cancel();
+            lock (_syncLock)
+            {
+                SetDownloadState(ProgressiveDownloadState.Incomplete, null);
+                _cacheStream?.Flush();
+                Monitor.PulseAll(_syncLock);
+            }
+        }
+    }
+
+    private void FailDownload(Exception error)
+    {
+        lock (_syncLock)
+        {
+            _downloadError = error;
+            SetLastError(MaResult.MaIoError, error);
+            SetDownloadState(ProgressiveDownloadState.Failed, error);
+            Monitor.PulseAll(_syncLock);
+        }
+    }
+
+    private void CancelDownload(ProgressiveDownloadState state)
+    {
+        _downloadCts?.Cancel();
+        if (_downloadState == ProgressiveDownloadState.Downloading)
+        {
+            lock (_syncLock)
+            {
+                SetDownloadState(state, null);
+                Monitor.PulseAll(_syncLock);
+            }
+        }
+    }
+
+    private void CancelStreamingPlayback()
+    {
+        _streamCts?.Cancel();
+        lock (_syncLock)
+        {
+            Monitor.PulseAll(_syncLock);
+        }
+    }
+
+    private void SetDownloadState(ProgressiveDownloadState state, Exception? error)
+    {
+        if (_downloadState == state && error == null)
+        {
+            return;
+        }
+
+        _downloadState = state;
+        DownloadStateChanged?.Invoke(
+            this,
+            new ProgressiveDownloadStateChangedEventArgs(
+                state,
+                error,
+                PartialFilePath,
+                state == ProgressiveDownloadState.Completed ? FinalFilePath : null));
+    }
+
+    private void PrepareOutputFiles(bool overwrite)
+    {
+        var directory = Path.GetDirectoryName(FinalFilePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        if (!overwrite && (File.Exists(FinalFilePath) || File.Exists(PartialFilePath)))
+        {
+            throw new IOException("The target progressive download file already exists.");
+        }
+
+        if (overwrite)
+        {
+            TryDelete(FinalFilePath);
+            TryDelete(PartialFilePath);
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // Best effort cleanup.
+        }
+    }
+
+    private sealed class ResponseStream(HttpResponseMessage response, Stream inner) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.ReadAsync(buffer, cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+                response.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await inner.DisposeAsync();
+            response.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/SimpleAudioPlayer/Handles/StreamHandle.cs
+++ b/SimpleAudioPlayer/Handles/StreamHandle.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Runtime.InteropServices;
 using SimpleAudioPlayer.Enums;
 
@@ -6,6 +6,8 @@ namespace SimpleAudioPlayer.Handles;
 
 public class StreamHandle(Stream stream): AudioCallbackHandlerBase
 {
+    public override bool CanSeek => stream.CanSeek;
+
     public override void Dispose()
     {
         stream.Dispose();
@@ -40,7 +42,7 @@ public class StreamHandle(Stream stream): AudioCallbackHandlerBase
         {
             return MaResult.MaNotImplemented;
         }
-        
+
         stream.Seek(offset, origin);
         return MaResult.MaSuccess;
     }
@@ -48,6 +50,18 @@ public class StreamHandle(Stream stream): AudioCallbackHandlerBase
     public override MaResult OnTell(IntPtr pDecoder, out long pCursor)
     {
         pCursor = stream.Position;
+        return MaResult.MaSuccess;
+    }
+
+    public override MaResult OnGetLength(out long length)
+    {
+        if (!stream.CanSeek)
+        {
+            length = 0;
+            return MaResult.MaNotImplemented;
+        }
+
+        length = stream.Length;
         return MaResult.MaSuccess;
     }
 }

--- a/SimpleAudioPlayer/Native/AudioCallbacks.cs
+++ b/SimpleAudioPlayer/Native/AudioCallbacks.cs
@@ -9,11 +9,13 @@ public unsafe class AudioCallbacks : IDisposable
     private GCHandle _readHandle;
     private GCHandle _seekHandle;
     private GCHandle _tellHandle;
+    private GCHandle _lengthHandle;
     private IAudioCallbackHandler? _handler;
 
     public NativeMethods.ReadDelegate ReadProxy { get; }
     public NativeMethods.SeekDelegate SeekProxy { get; }
     public NativeMethods.TellDelegate TellProxy { get; }
+    public NativeMethods.LengthDelegate LengthProxy { get; }
 
     public IAudioCallbackHandler? Handler
     {
@@ -27,10 +29,12 @@ public unsafe class AudioCallbacks : IDisposable
         ReadProxy = ProxyRead;
         SeekProxy = ProxySeek;
         TellProxy = ProxyTell;
+        LengthProxy = ProxyGetLength;
 
         _readHandle = GCHandle.Alloc(ReadProxy);
         _seekHandle = GCHandle.Alloc(SeekProxy);
         _tellHandle = GCHandle.Alloc(TellProxy);
+        _lengthHandle = GCHandle.Alloc(LengthProxy);
     }
 
     private MaResult ProxyRead(
@@ -39,7 +43,8 @@ public unsafe class AudioCallbacks : IDisposable
         nuint bytesToRead,
         out nuint bytesRead)
     {
-        if (_handler == null)
+        var handler = _handler;
+        if (handler == null)
         {
             bytesRead = 0;
             return MaResult.MaNotImplemented;
@@ -47,12 +52,17 @@ public unsafe class AudioCallbacks : IDisposable
 
         try
         {
-            var result = _handler.OnRead(pDecoder, pBuffer, bytesToRead, out var bytesReadInt);
+            var result = handler.OnRead(pDecoder, pBuffer, bytesToRead, out var bytesReadInt);
             bytesRead = bytesReadInt;
             return result;
         }
-        catch
+        catch (Exception ex)
         {
+            if (handler is AudioCallbackHandlerBase callbackHandler)
+            {
+                callbackHandler.SetLastError(MaResult.MaError, ex);
+            }
+
             bytesRead = 0;
             return MaResult.MaError;
         }
@@ -63,22 +73,29 @@ public unsafe class AudioCallbacks : IDisposable
         long offset,
         SeekOrigin origin)
     {
-        if (_handler == null)
+        var handler = _handler;
+        if (handler == null)
             return MaResult.MaNotImplemented;
 
         try
         {
-            return _handler.OnSeek(pDecoder, offset, origin);
+            return handler.OnSeek(pDecoder, offset, origin);
         }
-        catch
+        catch (Exception ex)
         {
+            if (handler is AudioCallbackHandlerBase callbackHandler)
+            {
+                callbackHandler.SetLastError(MaResult.MaError, ex);
+            }
+
             return MaResult.MaError;
         }
     }
 
     private MaResult ProxyTell(IntPtr pDecoder, out long pCursor)
     {
-        if (_handler == null)
+        var handler = _handler;
+        if (handler == null)
         {
             pCursor = 0;
             return MaResult.MaNotImplemented;
@@ -86,13 +103,43 @@ public unsafe class AudioCallbacks : IDisposable
 
         try
         {
-            var result = _handler.OnTell(pDecoder, out var pCursorInt);
+            var result = handler.OnTell(pDecoder, out var pCursorInt);
             pCursor = pCursorInt;
             return result;
         }
-        catch
+        catch (Exception ex)
         {
+            if (handler is AudioCallbackHandlerBase callbackHandler)
+            {
+                callbackHandler.SetLastError(MaResult.MaError, ex);
+            }
+
             pCursor = 0;
+            return MaResult.MaError;
+        }
+    }
+
+    private MaResult ProxyGetLength(IntPtr pDecoder, out long pLength)
+    {
+        var handler = _handler;
+        if (handler == null)
+        {
+            pLength = 0;
+            return MaResult.MaNotImplemented;
+        }
+
+        try
+        {
+            return handler.OnGetLength(out pLength);
+        }
+        catch (Exception ex)
+        {
+            if (handler is AudioCallbackHandlerBase callbackHandler)
+            {
+                callbackHandler.SetLastError(MaResult.MaError, ex);
+            }
+
+            pLength = 0;
             return MaResult.MaError;
         }
     }
@@ -103,6 +150,7 @@ public unsafe class AudioCallbacks : IDisposable
         if (_readHandle.IsAllocated) _readHandle.Free();
         if (_seekHandle.IsAllocated) _seekHandle.Free();
         if (_tellHandle.IsAllocated) _tellHandle.Free();
+        if (_lengthHandle.IsAllocated) _lengthHandle.Free();
     }
 
     internal void DisposeHandler()

--- a/SimpleAudioPlayer/Native/DeviceCallbacks.cs
+++ b/SimpleAudioPlayer/Native/DeviceCallbacks.cs
@@ -19,6 +19,8 @@ public class DeviceCallbacks: IDisposable
 
     public Action? PlayCompleted { get; set; }
 
+    public Action<MaResult>? PlaybackStopped { get; set; }
+
     public DeviceCallbacks(AudioContextHandle ctx, SampleFormat sampleFormat = SampleFormat.F32, uint channels = 2, uint sampleRate = 44100)
     {
         _ctx = ctx;
@@ -41,13 +43,35 @@ public class DeviceCallbacks: IDisposable
     {
         _scheduler.Post(() =>
         {
+            MaResult result;
             lock (_syncRoot)
             {
+                result = GetDecodeResult();
                 NativeMethods.AudioStop(_ctx);
             }
-            PlayCompleted?.Invoke();
+
+            if (PlaybackStopped != null)
+            {
+                PlaybackStopped.Invoke(result);
+            }
+            else if (result == MaResult.MaSuccess || result == MaResult.MaAtEnd)
+            {
+                PlayCompleted?.Invoke();
+            }
         });
-        
+         
+    }
+
+    private MaResult GetDecodeResult()
+    {
+        try
+        {
+            return NativeMethods.GetDecodeResult(_ctx);
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return MaResult.MaSuccess;
+        }
     }
 
     private void ProxyDeviceStateChanged(IntPtr pNotification)

--- a/SimpleAudioPlayer/Native/NativeMethods.cs
+++ b/SimpleAudioPlayer/Native/NativeMethods.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using SimpleAudioPlayer.Enums;
 
 namespace SimpleAudioPlayer.Native;
@@ -10,16 +10,19 @@ public static unsafe partial class NativeMethods
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate MaResult SeekDelegate(IntPtr pDecoder, long byteOffset, SeekOrigin origin);
-    
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate MaResult TellDelegate(IntPtr pDecoder, out long pCursor);
-    
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate MaResult LengthDelegate(IntPtr pDecoder, out long pLength);
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void StopCallback();
-    
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate void DeviceStateChangedCallback(IntPtr pNotification);
-    
+
     private const string LibraryName = "libaudio_player";
 
     [LibraryImport(LibraryName, EntryPoint = "audio_context_create")]
@@ -40,6 +43,8 @@ public static unsafe partial class NativeMethods
         ReadDelegate onRead,
         SeekDelegate onSeek,
         TellDelegate onTell,
+        LengthDelegate onGetLength,
+        uint canSeek,
         IntPtr userdata);
 
     [LibraryImport(LibraryName, EntryPoint = "audio_play")]
@@ -50,31 +55,34 @@ public static unsafe partial class NativeMethods
 
     [LibraryImport(LibraryName, EntryPoint = "audio_cleanup")]
     public static partial void AudioCleanup(IntPtr ctx);
-    
+
     [LibraryImport(LibraryName, EntryPoint = "seek_to_time")]
     public static partial MaResult SeekToTime(AudioContextHandle ctx, double seconds);
 
     [LibraryImport(LibraryName, EntryPoint = "get_decoder")]
     public static partial MaResult GetDecoder(AudioContextHandle ctx, out IntPtr pDecoder);
-    
+
     [LibraryImport(LibraryName, EntryPoint = "get_length_in_pcm_frames")]
     public static partial MaResult GetLengthInPcmFrames(AudioContextHandle ctx, out ulong frames);
 
     [LibraryImport(LibraryName, EntryPoint = "get_cursor_in_pcm_frames")]
     public static partial MaResult GetCursorInPcmFrames(AudioContextHandle ctx, out ulong frames);
-    
+
     [LibraryImport(LibraryName, EntryPoint = "get_time")]
     public static partial MaResult GetTime(AudioContextHandle ctx, out double seconds);
 
     [LibraryImport(LibraryName, EntryPoint = "get_duration")]
     public static partial MaResult GetDuration(AudioContextHandle ctx, out double seconds);
-    
+
     [LibraryImport(LibraryName, EntryPoint = "get_volume")]
     public static partial float GetVolume(AudioContextHandle ctx);
-    
+
     [LibraryImport(LibraryName, EntryPoint = "set_volume")]
     public static partial MaResult SetVolume(AudioContextHandle ctx, float volume);
-    
+
     [LibraryImport(LibraryName, EntryPoint = "get_play_state")]
     public static partial PlayState GetPlayState(AudioContextHandle ctx);
+
+    [LibraryImport(LibraryName, EntryPoint = "get_decode_result")]
+    public static partial MaResult GetDecodeResult(AudioContextHandle ctx);
 }

--- a/SimpleAudioPlayer/PlaybackFailedEventArgs.cs
+++ b/SimpleAudioPlayer/PlaybackFailedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using SimpleAudioPlayer.Enums;
+
+namespace SimpleAudioPlayer;
+
+public sealed class PlaybackFailedEventArgs : EventArgs
+{
+    public PlaybackFailedEventArgs(MaResult result, Exception? exception)
+    {
+        Result = result;
+        Exception = exception;
+    }
+
+    public MaResult Result { get; }
+
+    public Exception? Exception { get; }
+}

--- a/SimpleAudioPlayer/ProgressiveDownloadStateChangedEventArgs.cs
+++ b/SimpleAudioPlayer/ProgressiveDownloadStateChangedEventArgs.cs
@@ -1,0 +1,15 @@
+using SimpleAudioPlayer.Enums;
+
+namespace SimpleAudioPlayer;
+
+public sealed class ProgressiveDownloadStateChangedEventArgs(
+    ProgressiveDownloadState state,
+    Exception? error,
+    string partialFilePath,
+    string? finalFilePath)
+{
+    public ProgressiveDownloadState State { get; } = state;
+    public Exception? Error { get; } = error;
+    public string PartialFilePath { get; } = partialFilePath;
+    public string? FinalFilePath { get; } = finalFilePath;
+}

--- a/SimpleAudioPlayer/Utils/HttpClientExtensions.cs
+++ b/SimpleAudioPlayer/Utils/HttpClientExtensions.cs
@@ -12,13 +12,14 @@ public static class HttpClientExtensions
     {
         try
         {
-
             // Range请求验证
-            var rangeResponse = await httpClient.SendAsync(
-                new HttpRequestMessage(HttpMethod.Get, url)
-                {
-                    Headers = { Range = new RangeHeaderValue(0, 0) } // 请求第一个字节
-                });
+            using var request = new HttpRequestMessage(HttpMethod.Get, url)
+            {
+                Headers = { Range = new RangeHeaderValue(0, 0) } // 请求第一个字节
+            };
+            using var rangeResponse = await httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead);
 
             return ParseRangeResponse(rangeResponse);
         }
@@ -35,11 +36,13 @@ public static class HttpClientExtensions
         try
         {
             // Range请求验证
-            var rangeResponse = httpClient.Send(
-                new HttpRequestMessage(HttpMethod.Get, url)
-                {
-                    Headers = { Range = new RangeHeaderValue(0, 0) } // 请求第一个字节
-                });
+            using var request = new HttpRequestMessage(HttpMethod.Get, url)
+            {
+                Headers = { Range = new RangeHeaderValue(0, 0) } // 请求第一个字节
+            };
+            using var rangeResponse = httpClient.Send(
+                request,
+                HttpCompletionOption.ResponseHeadersRead);
 
             return ParseRangeResponse(rangeResponse);
         }
@@ -49,27 +52,15 @@ public static class HttpClientExtensions
         }
     }
 
-    private static (bool HasRange, long? Length) ParseHeaders(HttpResponseMessage response)
-    {
-        // 检查Accept-Ranges标头
-        var acceptRanges = response.Headers
-            .FirstOrDefault(h => h.Key.Equals("Accept-Ranges", StringComparison.OrdinalIgnoreCase))
-            .Value?.FirstOrDefault();
-
-        var hasRange = acceptRanges?.Equals("bytes", StringComparison.OrdinalIgnoreCase) ?? false;
-
-        // 获取Content-Length
-        var contentLength = response.Content.Headers.ContentLength;
-
-        return (hasRange, contentLength);
-    }
-
     private static (bool SupportsRange, long? FileSize) ParseRangeResponse(
         HttpResponseMessage response)
     {
         // 检查状态码
         if (response.StatusCode != HttpStatusCode.PartialContent)
-            return (false, null);
+        {
+            var contentLength = response.Content.Headers.ContentLength;
+            return (false, contentLength > 0 ? contentLength : null);
+        }
 
         // 优先从Content-Range获取文件大小
         var contentRange = response.Content.Headers.ContentRange;


### PR DESCRIPTION
## Summary
- 增加播放失败和状态变化事件，向上层暴露 native/stream 错误。
- 修正 HTTP、缓存和渐进下载场景中的 EOF/Error 语义，避免断流被当成正常播放结束。
- 新增磁盘缓存和 Progressive HTTP 播放 Handle，支持 Range 下边下边播、seek 后继续播放，以及 no-range 顺序落盘回退。

## Verification
- 本地构建通过。
- stream-error smoke 通过。
- format smoke 通过。