### PR TITLE
chore: release SimpleAudioPlayer 2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,15 +2,77 @@ name: package_nuget
 
 on:
   push:
-    tags: ['v*']
+    branches:
+      - master
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 env:
   PROJECT_DIR: ${{ github.workspace }}/SimpleAudioPlayer
 
 jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+
+    outputs:
+      should_release: ${{ steps.prepare.outputs.should_release }}
+      package_version: ${{ steps.prepare.outputs.package_version }}
+      tag_name: ${{ steps.prepare.outputs.tag_name }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Resolve version
+      id: prepare
+      shell: pwsh
+      run: |
+        [xml]$project = Get-Content -LiteralPath "${{ env.PROJECT_DIR }}/SimpleAudioPlayer.csproj"
+        $version = [string]$project.Project.PropertyGroup.Version
+
+        if ([string]::IsNullOrWhiteSpace($version)) {
+          throw "Version is missing in SimpleAudioPlayer.csproj."
+        }
+
+        $parsedVersion = $null
+        if (-not [Version]::TryParse($version, [ref]$parsedVersion)) {
+          throw "Version must be a stable numeric SemVer version such as 2.0.0. Current value: '$version'."
+        }
+
+        $tagName = "v$version"
+        $existingTag = git tag --list $tagName
+
+        "package_version=$version" >> $env:GITHUB_OUTPUT
+        "tag_name=$tagName" >> $env:GITHUB_OUTPUT
+
+        if (-not [string]::IsNullOrWhiteSpace($existingTag)) {
+          Write-Host "Tag '$tagName' already exists. Nothing to publish."
+          "should_release=false" >> $env:GITHUB_OUTPUT
+          exit 0
+        }
+
+        $latestTag = git tag --list "v[0-9]*" --sort=-v:refname | Select-Object -First 1
+        if (-not [string]::IsNullOrWhiteSpace($latestTag)) {
+          $latestVersionText = $latestTag.Substring(1)
+          $latestVersion = $null
+
+          if ([Version]::TryParse($latestVersionText, [ref]$latestVersion) -and $parsedVersion -le $latestVersion) {
+            throw "Version '$version' is not higher than the latest release tag '$latestTag'."
+          }
+        }
+
+        Write-Host "Preparing release '$tagName'."
+        "should_release=true" >> $env:GITHUB_OUTPUT
+
   package_nuget:
     name: Package NuGet
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -38,4 +100,23 @@ jobs:
             --api-key "${{ secrets.NUGET_API_KEY }}" \
             --skip-duplicate
         done
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN || github.token }}
+        TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+        PACKAGE_VERSION: ${{ needs.prepare.outputs.package_version }}
+      shell: bash
+      run: |
+        mapfile -t assets < <(find "${{ github.workspace }}/artifacts/nuget" -type f | sort)
+
+        if [ ${#assets[@]} -eq 0 ]; then
+          echo "No release assets were produced."
+          exit 1
+        fi
+
+        gh release create "$TAG_NAME" "${assets[@]}" \
+          --target "$GITHUB_SHA" \
+          --title "SimpleAudioPlayer $PACKAGE_VERSION" \
+          --generate-notes
     

--- a/README-zh.md
+++ b/README-zh.md
@@ -14,11 +14,19 @@
 - ⏲️ 获取播放时长和当前进度
 - 🔧 可扩展的流处理系统（支持自定义数据源）
 
+## 2.0 更新
+
+- Native 依赖升级到 **SimpleAudioPlayer.Native 2.0.0**。
+- 播放失败会通过 `PlaybackFailed` 和 `PlaybackState.Error` 暴露给调用方。
+- HTTP 流断开会报告 I/O 错误，不再静默当作正常 EOF。
+- `ProgressiveHttpStreamHandle` 支持边下边播，并在下载完成后落到最终本地文件。
+- `DiskCachedStreamHandle` 支持磁盘缓存，避免大文件全部放进内存。
+
 ## 安装
 
 通过 NuGet 安装：
 ```bash
-Install-Package SimpleAudioPlayer
+Install-Package SimpleAudioPlayer -Version 2.0.0
 ```
 
 ## 快速开始
@@ -42,6 +50,41 @@ var currentTime = player.GetTime();
 player.Seek(30);
 ```
 
+## 错误处理
+```csharp
+player.PlaybackStateChanged = state =>
+{
+    Console.WriteLine($"播放状态：{state}");
+};
+
+player.PlaybackFailed = args =>
+{
+    Console.WriteLine($"播放失败：{args.Result}");
+    Console.WriteLine(args.Exception);
+};
+```
+
+## HTTP 边下边播
+```csharp
+var handle = await ProgressiveHttpStreamHandle.CreateAsync(
+    "https://example.com/song.mp3",
+    "song.mp3",
+    overwrite: true);
+
+handle.ProgressChanged += (downloaded, total) =>
+{
+    Console.WriteLine($"{downloaded}/{total}");
+};
+
+handle.DownloadStateChanged += (_, args) =>
+{
+    Console.WriteLine($"下载状态：{args.State}");
+};
+
+player.Load(handle);
+player.Play();
+```
+
 ## 流处理支持
 
 |处理器类型|描述|
@@ -51,11 +94,13 @@ player.Seek(30);
 |StreamHandle|通用流（需提供Stream对象）|
 |CustomHandle|完全自定义实现|
 |CachedStreamHandle|网络流缓存支持|
+|DiskCachedStreamHandle|适合大文件的磁盘缓存流|
+|ProgressiveHttpStreamHandle|HTTP 边下边播，并保存为最终本地文件|
 
 ## 依赖说明
 - 后端使用 [miniaudio](https://github.com/mackron/miniaudio) 进行音频播放
 - 音频解码通过 [FFmpeg](https://ffmpeg.org/) 实现
-- Native组件使用 [SimpleAudioPlayer.Native](https://github.com/j4587698/SimpleAudioPlayer.Native) (LGPL-2.1+)
+- Native组件使用 [SimpleAudioPlayer.Native 2.0.0](https://github.com/j4587698/SimpleAudioPlayer.Native) (LGPL-2.1+)
 
 ## 许可证
 主项目采用 MIT License

--- a/README.md
+++ b/README.md
@@ -11,10 +11,17 @@ A simple cross-platform audio playback library with **SimpleAudioPlayer.Native (
 - ⏲️ Track duration and progress monitoring
 - 🔧 Extensible stream handling system (custom data sources)
 
+## What's New in 2.0
+- Native dependency updated to **SimpleAudioPlayer.Native 2.0.0**.
+- Playback failures now surface through `PlaybackFailed` and `PlaybackState.Error`.
+- HTTP stream handlers report I/O failures instead of silently treating broken streams as EOF.
+- `ProgressiveHttpStreamHandle` supports play-while-downloading to a final local file.
+- `DiskCachedStreamHandle` caches streamed data on disk to avoid holding large files in memory.
+
 ## Installation Via NuGet:
 
 ```bash
-Install-Package SimpleAudioPlayer
+Install-Package SimpleAudioPlayer -Version 2.0.0
 ```
 
 ## Quick Start
@@ -34,6 +41,41 @@ var currentTime = player.GetTime();
 player.Seek(30);
 ```
 
+## Error Handling
+```csharp
+player.PlaybackStateChanged = state =>
+{
+    Console.WriteLine($"Playback state: {state}");
+};
+
+player.PlaybackFailed = args =>
+{
+    Console.WriteLine($"Playback failed: {args.Result}");
+    Console.WriteLine(args.Exception);
+};
+```
+
+## Progressive HTTP Download
+```csharp
+var handle = await ProgressiveHttpStreamHandle.CreateAsync(
+    "https://example.com/song.mp3",
+    "song.mp3",
+    overwrite: true);
+
+handle.ProgressChanged += (downloaded, total) =>
+{
+    Console.WriteLine($"{downloaded}/{total}");
+};
+
+handle.DownloadStateChanged += (_, args) =>
+{
+    Console.WriteLine($"Download state: {args.State}");
+};
+
+player.Load(handle);
+player.Play();
+```
+
 ## Stream Handlers 
 | Handler Type | Description |
 |-----------------------|------------------------------|
@@ -42,11 +84,13 @@ player.Seek(30);
 | `StreamHandle` | Generic stream (requires Stream object) |
 | `CustomHandle` | Fully customizable implementation |
 | `CachedStreamHandle` | Caching support for network streams |
+| `DiskCachedStreamHandle` | Disk-backed cache for large streams |
+| `ProgressiveHttpStreamHandle` | HTTP play-while-downloading with a final local file |
 
 ## Dependencies
 - Audio playback via [miniaudio](https://github.com/mackron/miniaudio)
 - Audio decoding via [FFmpeg](https://ffmpeg.org/)
-- Native component: [SimpleAudioPlayer.Native](https://github.com/j4587698/SimpleAudioPlayer.Native) (LGPL-2.1+)
+- Native component: [SimpleAudioPlayer.Native 2.0.0](https://github.com/j4587698/SimpleAudioPlayer.Native) (LGPL-2.1+)
 
 ## License - Main project: **[MIT License](LICENSE)** 
 - Native component: **[LGPL-2.1+](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)**

--- a/SimpleAudioPlayer/SimpleAudioPlayer.csproj
+++ b/SimpleAudioPlayer/SimpleAudioPlayer.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-        <Version>1.8.4</Version>
+        <Version>2.0.0</Version>
         <Authors>Jx</Authors>
         <Company>JxAudio</Company>
         <Description>Simple Audio Player with miniaudio and ffmpeg</Description>
@@ -25,7 +25,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="SimpleAudioPlayer.Native" Version="1.8.2" />
+        <PackageReference Include="SimpleAudioPlayer.Native" Version="2.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- bump SimpleAudioPlayer package version to 2.0.0
- update SimpleAudioPlayer.Native dependency to 2.0.0
- add 2.0 release notes and progressive streaming documentation
- enable release workflow to publish when the csproj version tag does not exist